### PR TITLE
fix: Correct oversized search icon on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
         The ultimate resource for product guides and instructions.
       </p>
       <div className="max-w-2xl mx-auto mb-16">
-        <div className="relative">
+        <div className="relative flex items-center">
           {/* TODO: Implement search functionality */}
           <input
             type="text"
@@ -19,20 +19,23 @@ export default function Home() {
             className="w-full p-4 pl-12 border border-gray-300 rounded-full bg-white text-lg focus:ring-2 focus:ring-apple-blue focus:border-transparent transition"
             disabled
           />
-          <svg
-            className="absolute left-4 top-1/2 -translate-y-1/2 h-6 w-6 text-apple-gray"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+          <div className="absolute left-4">
+            <svg
+              style={{ width: '24px', height: '24px' }}
+              className="text-apple-gray"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div>


### PR DESCRIPTION
This commit fixes a UI bug where the search icon on the homepage was rendering at an extremely large size, often taking up the entire screen.

The root cause appears to be an issue with the build environment where the Tailwind CSS classes for sizing (h-6, w-6) were not being applied to the SVG element.

To provide a robust fix that is not dependent on the build process, the icon's size is now constrained using inline styles, setting its width and height to 24px. The surrounding layout has also been slightly adjusted to ensure the icon is properly centered.